### PR TITLE
Add user-defined :metrics support, Disable when not published

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ https://github.com/github/scientist, but for Clojure (api and readme liberally s
 (def my-experiment
   {:name "widget-permissions"
    :use (fn [widget user] (check-user? widget user))
-   :try (fn [widget user] (allowed-to? :read user widget))})
+   :try (fn [widget user] (allowed-to? :read user widget))
+   :publish prn})
 
 (science/run my-experiment widget user)
 ```
@@ -24,12 +25,13 @@ The function under `:use` is the "control" (the original code you used to have).
 The function under `:try` is the "experiment" (the new code that you want to compare).
 
 Experiments are just maps with some data and functions in them.
-There are a lot of options though. `:use`, `:try` and `:name` are the only required keys.
+There are a lot of options though. `:use`, `:try` and `:name` are the only required keys,
+but experiments won't run if their results aren't published.
 
 ### Making Science Useful
 
-The above example will run, but it's not doing anything particularly useful.
-To make it useful, the very minimum you'll need to do is to be able to `:publish` results:
+The above example will run, but it's only printing out results.
+To make it more useful, the `:publish` function could be enhanced:
 
 ```clojure
 :publish (fn [result] ; whatever you want to do on results happens here
@@ -38,24 +40,28 @@ To make it useful, the very minimum you'll need to do is to be able to `:publish
 
 ## Results
 
-Results passed to `:publish` are just a map (actually a record):
+Results passed to `:publish` are a Record:
 
 ```
 {:name "widget-permissions"
+ :experiment {the original experiment map/record}
+ :args [a vector of the args passed to the use/try functions]
   :control
   {
-    :duration 10 ; number of milliseconds the control took
+    :metrics {:duration-ns 10} ; number of nanoseconds the control took
     :value true  ; whatever value your :use function returned
   }
   :candidate
   {
-    :duration 3  ; number of milliseconds the candidate took
+    :metrics {:duration-ns 3}  ; number of nanoseconds the candidate took
     :value true  ; whatever value your :try function returned
   }
 }
 ```
 
 ## Ramping up Experiments
+
+### Deciding to enable an experiment
 
 To control if your `:try` function runs, you can pass a `:enabled` function in an experiment:
 
@@ -65,15 +71,41 @@ To control if your `:try` function runs, you can pass a `:enabled` function in a
 
 Note that this function will be called for every invocation of every experiment.
 Be very sensitive to it's performance.
-I'd recommend using something like https://github.com/yeller/shoutout for this.
+Feature flags are recommended - consider using something like https://github.com/yeller/shoutout for this.
+
+### User-defined metrics
+
+Experiments can also execute user-defined metrics for the control and the candidate.
+Metrics are 0-arity functions that return some number.  Metrics are called before
+and after executing the function under inspection, and the difference is logged
+in the result's `:metrics`.
+
+An experiment will take a map of additional metrics.  Additional metrics will
+have an impact on experiment execution time - be mindful of performance.
+Here is an experiment that calculates a very crude memory metric:
+
+```clojure
+(require '[laboratory.experiment :as science])
+
+(def my-experiment
+  {:name "widget-permissions"
+   :use (fn [widget user] (check-user? widget user))
+   :try (fn [widget user] (allowed-to? :read user widget))
+   :publish prn
+   :metrics {:bytes-used #(- (.totalMemory (Runtime/getRuntime))
+                             (.freeMemory (Runtime/getRuntime)))}})
+
+(science/run my-experiment widget user)
+```
 
 ## Faster, more Validated Science
 
-Whilst running experiments as maps is easy, and very flexible, looking keys up in maps ain't the fastest thing for the JVM
-to optimize. Instead laboratory offers a simple record wrapper for experiments, which dramatically changes performance:
+Defining experiments as maps is easy and very flexible, however, their impact on the JVM will be noticeable.
+You may optionally use the `Experiment` record to enhance performance, but you
+must supply all experiment keys `[:enabled :publish :metrics :use :try]`:
 
 ```clojure
-(science/make-it-faster! experiment) ; returns a record
+(science/map->Experiment my-experiment) ; returns a record
 ```
 
 ## Rationale

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,11 @@
   :url "https://github.com/yeller/laboratory"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]]
-  :profiles {:dev {:dependencies [[org.clojure/tools.namespace "0.2.4"]
-                                  [bolth "0.2.0-SNAPSHOT"]]}
+  :dependencies [[org.clojure/clojure "1.8.0"]]
+  :profiles {:dev {:dependencies [[org.clojure/tools.namespace "0.2.4"]]}
              :benches {:dependencies [[criterium "0.4.1"]]
-                       :source-paths ["src" "benches"]}})
+                       :source-paths ["src" "benches"]}}
+  :global-vars {*warn-on-reflection* true
+                *unchecked-math* :warn-on-boxed
+                ;*compiler-options* {:disable-locals-clearing true}
+                *assert* true})

--- a/src/laboratory/experiment.clj
+++ b/src/laboratory/experiment.clj
@@ -1,108 +1,164 @@
 (ns laboratory.experiment)
 
-(defrecord ExperimentSideResult [duration value])
+(defrecord Experiment [enabled publish metrics use try])
+(defrecord ExperimentSideResult [value metrics])
+(defrecord ExperimentResult [name experiment args control candidate])
 
-(defrecord ExperimentResult [name control candidate])
+(def always-enabled (constantly true))
+(def publish-nowhere (constantly nil))
 
-(defn always-enabled [& _]
-  true)
-
-(defn publish-nowhere [_])
-
-(defn nanos->ms [nanos]
+(defn nanos->ms [^long nanos]
   (float  (/  nanos 1000000)))
 
 (defn run-with-result
-  ([f]
-   (let [t0 (System/nanoTime)
+  ([f metrics]
+   (let [metrics0 (mapv #(%) (vals metrics))
+         t0 (System/nanoTime)
          result (try (f) (catch Exception e e))
-         t1 (System/nanoTime)]
-     (->ExperimentSideResult (nanos->ms (- t1 t0)) result)))
-  ([f arg1]
-   (let [t0 (System/nanoTime)
+         t1 (System/nanoTime)
+         metrics1 (mapv #(%) (vals metrics))]
+     (->ExperimentSideResult result (merge {:duration-ns (unchecked-subtract t1 t0)}
+                                           (zipmap (keys metrics) (map - metrics1 metrics0))))))
+  ([f metrics arg1]
+   (let [metrics0 (mapv #(%) (vals metrics))
+         t0 (System/nanoTime)
          result (try (f arg1) (catch Exception e e))
-         t1 (System/nanoTime)]
-     (->ExperimentSideResult (nanos->ms (- t1 t0)) result)))
-  ([f arg1 arg2]
-   (let [t0 (System/nanoTime)
+         t1 (System/nanoTime)
+         metrics1 (mapv #(%) (vals metrics))]
+     (->ExperimentSideResult result (merge {:duration-ns (unchecked-subtract t1 t0)}
+                                           (zipmap (keys metrics) (map - metrics1 metrics0))))))
+  ([f metrics arg1 arg2]
+   (let [metrics0 (mapv #(%) (vals metrics))
+         t0 (System/nanoTime)
          result (try (f arg1 arg2) (catch Exception e e))
-         t1 (System/nanoTime)]
-     (->ExperimentSideResult (nanos->ms (- t1 t0)) result)))
-  ([f arg1 arg2 arg3]
-   (let [t0 (System/nanoTime)
+         t1 (System/nanoTime)
+         metrics1 (mapv #(%) (vals metrics))]
+     (->ExperimentSideResult result (merge {:duration-ns (unchecked-subtract t1 t0)}
+                                           (zipmap (keys metrics) (map - metrics1 metrics0))))))
+  ([f metrics arg1 arg2 arg3]
+   (let [metrics0 (mapv #(%) (vals metrics))
+         t0 (System/nanoTime)
          result (try (f arg1 arg2 arg3) (catch Exception e e))
-         t1 (System/nanoTime)]
-     (->ExperimentSideResult (nanos->ms (- t1 t0)) result)))
-  ([f arg1 arg2 arg3 & args]
-   (let [t0 (System/nanoTime)
-         result (try (apply f arg1 arg2 arg3 args) (catch Exception e e))
-         t1 (System/nanoTime)]
-     (->ExperimentSideResult (nanos->ms (- t1 t0)) result))))
+         t1 (System/nanoTime)
+         metrics1 (mapv #(%) (vals metrics))]
+     (->ExperimentSideResult result (merge {:duration-ns (unchecked-subtract t1 t0)}
+                                           (zipmap (keys metrics) (map - metrics1 metrics0))))))
 
-(defn make-result [experiment control-result candidate-result]
-  (->ExperimentResult (:name experiment) control-result candidate-result))
+  ([f metrics arg1 arg2 arg3 arg4]
+   (let [metrics0 (mapv #(%) (vals metrics))
+         t0 (System/nanoTime)
+         result (try (f arg1 arg2 arg3 arg4) (catch Exception e e))
+         t1 (System/nanoTime)
+         metrics1 (mapv #(%) (vals metrics))]
+     (->ExperimentSideResult result (merge {:duration-ns (unchecked-subtract t1 t0)}
+                                           (zipmap (keys metrics) (map - metrics1 metrics0))))))
+  ([f metrics arg1 arg2 arg3 arg4 & args]
+   (let [metrics0 (mapv #(%) (vals metrics))
+         t0 (System/nanoTime)
+         result (try (apply f arg1 arg2 arg3 arg4 args) (catch Exception e e))
+         t1 (System/nanoTime)
+         metrics1 (mapv #(%) (vals metrics))]
+     (->ExperimentSideResult result (merge {:duration-ns (unchecked-subtract t1 t0)}
+                                           (zipmap (keys metrics) (map - metrics1 metrics0)))))))
+
+(defn make-result [experiment args control-result candidate-result]
+  (->ExperimentResult (:name experiment) experiment args control-result candidate-result))
 
 (defn run
+  "Given an experiment map
+  Run the experiment, capturing the `:duration-ns` and other experiment `:metrics`.
+  If the results are set to `publish-nowhere`, the experiment isn't run,
+   if no one is looking at the results, the experiment isn't worth conducting."
   ([experiment]
-   (if ((or (:enabled experiment) always-enabled))
-     (let [control-result (run-with-result (:use experiment))
-           candidate-result (run-with-result (:try experiment))]
-       ((or (:publish experiment) publish-nowhere) (make-result experiment control-result candidate-result))
+   (if (and ((:enabled experiment always-enabled))
+            (:publish experiment)
+            (not= (:publish experiment) publish-nowhere))
+     (let [control-result (run-with-result (:use experiment) (:metrics experiment))
+           candidate-result (run-with-result (:try experiment) (:metrics experiment))]
+       ((:publish experiment publish-nowhere) (make-result experiment [] control-result candidate-result))
        (if (instance? Throwable (:value control-result))
-         (throw (:value control-result)))
-       (:value control-result))
-
+         (throw (:value control-result))
+         (:value control-result)))
      ((:use experiment))))
 
   ([experiment arg1]
-   (if ((or (:enabled experiment) always-enabled) arg1)
-     (let [control-result (run-with-result (:use experiment) arg1)
-           candidate-result (run-with-result (:try experiment) arg1)]
-       ((or (:publish experiment) publish-nowhere) (make-result experiment control-result candidate-result))
+   (if (and ((:enabled experiment always-enabled) arg1)
+            (:publish experiment)
+            (not= (:publish experiment) publish-nowhere))
+     (let [control-result (run-with-result (:use experiment) (:metrics experiment) arg1)
+           candidate-result (run-with-result (:try experiment) (:metrics experiment) arg1)]
+       ((:publish experiment publish-nowhere) (make-result experiment [arg1] control-result candidate-result))
        (if (instance? Throwable (:value control-result))
-         (throw (:value control-result)))
-       (:value control-result))
-
+         (throw (:value control-result))
+         (:value control-result)))
      ((:use experiment) arg1)))
 
   ([experiment arg1 arg2]
-   (if ((or (:enabled experiment) always-enabled) arg1 arg2)
-     (let [control-result (run-with-result (:use experiment) arg1 arg2)
-           candidate-result (run-with-result (:try experiment) arg1 arg2)]
-       ((or (:publish experiment) publish-nowhere) (make-result experiment control-result candidate-result))
+   (if (and ((:enabled experiment always-enabled) arg1 arg2)
+            (:publish experiment)
+            (not= (:publish experiment) publish-nowhere))
+     (let [control-result (run-with-result (:use experiment) (:metrics experiment) arg1 arg2)
+           candidate-result (run-with-result (:try experiment) (:metrics experiment) arg1 arg2)]
+       ((:publish experiment publish-nowhere) (make-result experiment [arg1 arg2] control-result candidate-result))
        (if (instance? Throwable (:value control-result))
-         (throw (:value control-result)))
-       (:value control-result))
-
+         (throw (:value control-result))
+         (:value control-result)))
      ((:use experiment) arg1 arg2)))
 
 
   ([experiment arg1 arg2 arg3]
-   (if ((or (:enabled experiment) always-enabled) arg1 arg2 arg3)
-     (let [control-result (run-with-result (:use experiment) arg1 arg2 arg3)
-           candidate-result (run-with-result (:try experiment) arg1 arg2 arg3)]
-       ((or (:publish experiment) publish-nowhere) (make-result experiment control-result candidate-result))
+   (if (and ((:enabled experiment always-enabled) arg1 arg2 arg3)
+            (:publish experiment)
+            (not= (:publish experiment) publish-nowhere))
+     (let [control-result (run-with-result (:use experiment) (:metrics experiment) arg1 arg2 arg3)
+           candidate-result (run-with-result (:try experiment) (:metrics experiment) arg1 arg2 arg3)]
+       ((:publish experiment publish-nowhere) (make-result experiment [arg1 arg2 arg3] control-result candidate-result))
        (if (instance? Throwable (:value control-result))
-         (throw (:value control-result)))
-       (:value control-result))
-
+         (throw (:value control-result))
+         (:value control-result)))
      ((:use experiment) arg1 arg2 arg3)))
 
-
-  ([experiment arg1 arg2 arg3 & args]
-   (if (apply (or (:enabled experiment) always-enabled) arg1 arg2 arg3 args)
-     (let [control-result (apply run-with-result (:use experiment) arg1 arg2 arg3 args)
-           candidate-result (apply run-with-result (:try experiment) arg1 arg2 arg3 args)]
-       ((or (:publish experiment) publish-nowhere) (make-result experiment control-result candidate-result))
+  ([experiment arg1 arg2 arg3 arg4]
+   (if (and ((:enabled experiment always-enabled) arg1 arg2 arg3 arg4)
+            (:publish experiment)
+            (not= (:publish experiment) publish-nowhere))
+     (let [control-result (run-with-result (:use experiment) (:metrics experiment) arg1 arg2 arg3 arg4)
+           candidate-result (run-with-result (:try experiment) (:metrics experiment) arg1 arg2 arg3 arg4)]
+       ((:publish experiment publish-nowhere) (make-result experiment [arg1 arg2 arg3 arg4] control-result candidate-result))
        (if (instance? Throwable (:value control-result))
-         (throw (:value control-result)))
-       (:value control-result))
+         (throw (:value control-result))
+         (:value control-result)))
+     ((:use experiment) arg1 arg2 arg3 arg4)))
 
-     (apply (:use experiment) arg1 arg2 arg3 args))))
+  ([experiment arg1 arg2 arg3 arg4 & args]
+   (if (and (apply (:enabled experiment always-enabled) arg1 arg2 arg3 arg4 args)
+            (:publish experiment)
+            (not= (:publish experiment) publish-nowhere))
+     (let [control-result (apply run-with-result (:use experiment) (:metrics experiment) arg1 arg2 arg3 arg4 args)
+           candidate-result (apply run-with-result (:try experiment) (:metrics experiment) arg1 arg2 arg3 arg4 args)]
+       ((:publish experiment publish-nowhere) (make-result experiment (into [arg1 arg2 arg3 arg4] args) control-result candidate-result))
+       (if (instance? Throwable (:value control-result))
+         (throw (:value control-result))
+         (:value control-result)))
+     (apply (:use experiment) arg1 arg2 arg3 arg4 args))))
 
-(defrecord FasterExperiment [enabled publish use try])
 
-(defn make-it-faster! [experiment]
-  (map->FasterExperiment experiment))
 
-; TODO unroll `run`
+(comment
+
+  (defn add5 [x]
+    (+ x 5))
+
+  (defn add5fast [^long x]
+    (unchecked-add x 5))
+
+  (def experiment {:name "Add5"
+                   :use add5
+                   :try add5fast
+                   :publish prn
+                   :metrics {:used-bytes #(- (.totalMemory (Runtime/getRuntime))
+                                             (.freeMemory (Runtime/getRuntime)))}})
+
+  (time (add5fast 1))
+  (time (run experiment 1))
+  )

--- a/src/laboratory/experiment.clj
+++ b/src/laboratory/experiment.clj
@@ -67,12 +67,11 @@
 (defn run
   "Given an experiment map
   Run the experiment, capturing the `:duration-ns` and other experiment `:metrics`.
-  If the results are set to `publish-nowhere`, the experiment isn't run,
+  If the results aren't `:publish`ed, the experiment isn't run,
    if no one is looking at the results, the experiment isn't worth conducting."
   ([experiment]
    (if (and ((:enabled experiment always-enabled))
-            (:publish experiment)
-            (not= (:publish experiment) publish-nowhere))
+            (:publish experiment))
      (let [control-result (run-with-result (:use experiment) (:metrics experiment))
            candidate-result (run-with-result (:try experiment) (:metrics experiment))]
        ((:publish experiment publish-nowhere) (make-result experiment [] control-result candidate-result))
@@ -83,8 +82,7 @@
 
   ([experiment arg1]
    (if (and ((:enabled experiment always-enabled) arg1)
-            (:publish experiment)
-            (not= (:publish experiment) publish-nowhere))
+            (:publish experiment))
      (let [control-result (run-with-result (:use experiment) (:metrics experiment) arg1)
            candidate-result (run-with-result (:try experiment) (:metrics experiment) arg1)]
        ((:publish experiment publish-nowhere) (make-result experiment [arg1] control-result candidate-result))
@@ -95,8 +93,7 @@
 
   ([experiment arg1 arg2]
    (if (and ((:enabled experiment always-enabled) arg1 arg2)
-            (:publish experiment)
-            (not= (:publish experiment) publish-nowhere))
+            (:publish experiment))
      (let [control-result (run-with-result (:use experiment) (:metrics experiment) arg1 arg2)
            candidate-result (run-with-result (:try experiment) (:metrics experiment) arg1 arg2)]
        ((:publish experiment publish-nowhere) (make-result experiment [arg1 arg2] control-result candidate-result))
@@ -108,8 +105,7 @@
 
   ([experiment arg1 arg2 arg3]
    (if (and ((:enabled experiment always-enabled) arg1 arg2 arg3)
-            (:publish experiment)
-            (not= (:publish experiment) publish-nowhere))
+            (:publish experiment))
      (let [control-result (run-with-result (:use experiment) (:metrics experiment) arg1 arg2 arg3)
            candidate-result (run-with-result (:try experiment) (:metrics experiment) arg1 arg2 arg3)]
        ((:publish experiment publish-nowhere) (make-result experiment [arg1 arg2 arg3] control-result candidate-result))
@@ -120,8 +116,7 @@
 
   ([experiment arg1 arg2 arg3 arg4]
    (if (and ((:enabled experiment always-enabled) arg1 arg2 arg3 arg4)
-            (:publish experiment)
-            (not= (:publish experiment) publish-nowhere))
+            (:publish experiment))
      (let [control-result (run-with-result (:use experiment) (:metrics experiment) arg1 arg2 arg3 arg4)
            candidate-result (run-with-result (:try experiment) (:metrics experiment) arg1 arg2 arg3 arg4)]
        ((:publish experiment publish-nowhere) (make-result experiment [arg1 arg2 arg3 arg4] control-result candidate-result))
@@ -132,8 +127,7 @@
 
   ([experiment arg1 arg2 arg3 arg4 & args]
    (if (and (apply (:enabled experiment always-enabled) arg1 arg2 arg3 arg4 args)
-            (:publish experiment)
-            (not= (:publish experiment) publish-nowhere))
+            (:publish experiment))
      (let [control-result (apply run-with-result (:use experiment) (:metrics experiment) arg1 arg2 arg3 arg4 args)
            candidate-result (apply run-with-result (:try experiment) (:metrics experiment) arg1 arg2 arg3 arg4 args)]
        ((:publish experiment publish-nowhere) (make-result experiment (into [arg1 arg2 arg3 arg4] args) control-result candidate-result))
@@ -141,7 +135,6 @@
          (throw (:value control-result))
          (:value control-result)))
      (apply (:use experiment) arg1 arg2 arg3 arg4 args))))
-
 
 
 (comment

--- a/test/laboratory/experiment_test.clj
+++ b/test/laboratory/experiment_test.clj
@@ -5,17 +5,20 @@
 (deftest run-experiment-test
   (testing "always returns the control result"
     (is (= (science/run {:use (fn [] 1)
-                         :try (fn [] 2)})
+                         :try (fn [] 2)
+                         :publish identity})
            1)))
 
   (testing "doesn't blow up if the candidate throws an exception"
     (is (= (science/run {:use (fn [] 1)
-                         :try (fn [] (throw (ex-info "blowing up" {})))})
+                         :try (fn [] (throw (ex-info "blowing up" {})))
+                         :publish identity})
            1)))
 
   (testing "blows up if the control blows up"
     (is (thrown? Exception (science/run {:use (fn [] (throw (ex-info "blowing up" {})))
-                                         :try (fn [] 1)}))))
+                                         :try (fn [] 1)
+                                         :publish identity}))))
 
   (testing "publishes the values"
     (let [published (atom nil)]
@@ -32,8 +35,20 @@
                     :try (fn [] 2)
                     :publish (fn [result]
                                (reset! published result))})
-      (is (pos? (-> @published :control :duration)))
-      (is (pos? (-> @published :candidate :duration)))))
+      (is (pos? (-> @published :control :metrics :duration-ns)))
+      (is (pos? (-> @published :candidate :metrics :duration-ns)))))
+
+  (testing "publishes the user-defined metrics, in addition to durations"
+    (let [published (atom nil)]
+      (science/run {:use (fn [] 1)
+                    :try (fn [] 2)
+                    :publish (fn [result]
+                               (reset! published result))
+                    :metrics {:a-number #(inc (rand-int 10))}})
+      (is (pos? (-> @published :control :metrics :duration-ns)))
+      (is (pos? (-> @published :candidate :metrics :duration-ns)))
+      (is (number? (-> @published :control :metrics :a-number)))
+      (is (number? (-> @published :candidate :metrics :a-number)))))
 
   (testing "doesn't publish if the experiment is disabled"
     (let [published (atom nil)]
@@ -43,9 +58,17 @@
                     :enabled (fn [] false)})
       (is (= @published nil))))
 
+  (testing "experiment is disabled if it isn't published"
+    (let [tried (atom nil)]
+      (science/run {:use (fn [] 1)
+                    :try (fn [] (reset! tried 2))})
+      (is (= @tried nil))))
+
   (testing "it returns the result after being made faster"
-    (is (= (science/run (science/make-it-faster! {:use (fn [] 1)
-                                                  :try (fn [] 2)}))
+    (is (= (science/run (science/map->Experiment {:use (fn [] 1)
+                                                  :try (fn [] 2)
+                                                  :metrics {}
+                                                  :enabled (constantly true)}))
            1)))
 
   (dotimes [n 10]
@@ -60,6 +83,7 @@
     (testing (str "it works with " n " args")
       (let [experiment (eval `{:use (fn [~@(map symbol (map #(str "arg" %) (range n)))] 1)
                                :try (fn [~@(map symbol (map #(str "arg" %) (range n)))] 2)
-                               :enabled (fn [~@(map symbol (map #(str "arg" %) (range n)))] false)})]
+                               :enabled (fn [~@(map symbol (map #(str "arg" %) (range n)))] false)
+                               :metrics {}})]
         (is (= 1 (apply science/run experiment (range n))))
-        (is (= 1 (apply science/run (science/make-it-faster! experiment) (range n))))))))
+        (is (= 1 (apply science/run (science/map->Experiment experiment) (range n))))))))

--- a/test/laboratory/experiment_test.clj
+++ b/test/laboratory/experiment_test.clj
@@ -68,6 +68,7 @@
     (is (= (science/run (science/map->Experiment {:use (fn [] 1)
                                                   :try (fn [] 2)
                                                   :metrics {}
+                                                  :publish identity
                                                   :enabled (constantly true)}))
            1)))
 
@@ -75,15 +76,18 @@
     (testing (str "it works with " n " args")
       (let [experiment (eval `{:use (fn [~@(map symbol (map #(str "arg" %) (range n)))] 1)
                                :try (fn [~@(map symbol (map #(str "arg" %) (range n)))] 2)
-                               :enabled (fn [~@(map symbol (map #(str "arg" %) (range n)))] true)})]
+                               :enabled (fn [~@(map symbol (map #(str "arg" %) (range n)))] true)
+                               :metrics {}
+                               :publish identity})]
         (is (= 1 (apply science/run experiment (range n))))
-        (is (= 1 (apply science/run (science/make-it-faster! experiment) (range n)))))))
+        (is (= 1 (apply science/run (science/map->Experiment experiment) (range n)))))))
 
   (dotimes [n 10]
     (testing (str "it works with " n " args")
       (let [experiment (eval `{:use (fn [~@(map symbol (map #(str "arg" %) (range n)))] 1)
                                :try (fn [~@(map symbol (map #(str "arg" %) (range n)))] 2)
                                :enabled (fn [~@(map symbol (map #(str "arg" %) (range n)))] false)
-                               :metrics {}})]
+                               :metrics {}
+                               :publish identity})]
         (is (= 1 (apply science/run experiment (range n))))
         (is (= 1 (apply science/run (science/map->Experiment experiment) (range n))))))))


### PR DESCRIPTION
This pull request makes the following changes:
- Experiments are disabled when results aren't published (only pay for what you use)
- Experiments now support user-defined metrics via a map of 0-arity functions; Duration is always performed
- Duration is left in nanoseconds; Users can format in the Publisher if they desire
- `make-it-fast!` was removed because it's not obvious what it does; One should prefer to use what Clojure offers by default if it applies (`map->Experiment`)
- Unrolled one more level of args (I have a handful of functions that are 4-arity in one codebase)
- Prefer Clojure's `not-found` argument in map lookup to `or`
- Enhance the tests to cover all changes
- Update the README to cover all changes
